### PR TITLE
Bootstrap Next.js app with Firebase auth scaffolding

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,6 @@
+/node_modules
+/.next
+/out
+.env.local
+.env.*
+.next

--- a/web/app/(auth)/signin/page.js
+++ b/web/app/(auth)/signin/page.js
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  signInWithEmailAndPassword,
+  GoogleAuthProvider,
+  signInWithPopup
+} from 'firebase/auth';
+import { auth } from '@/lib/firebaseClient';
+
+const googleProvider = new GoogleAuthProvider();
+
+googleProvider.setCustomParameters({ prompt: 'select_account' });
+
+export default function SignInPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const exchangeSession = async (idToken) => {
+    const res = await fetch('/api/auth/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ idToken })
+    });
+
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      throw new Error(data.error || 'Failed to establish session');
+    }
+  };
+
+  const handleEmailPassword = async (event) => {
+    event.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const credential = await signInWithEmailAndPassword(auth, email, password);
+      const idToken = await credential.user.getIdToken();
+      await exchangeSession(idToken);
+      await auth.signOut();
+      router.push('/dashboard');
+      router.refresh();
+    } catch (err) {
+      setError(err.message || 'Unable to sign in.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleGoogle = async () => {
+    setError('');
+    setLoading(true);
+
+    try {
+      const credential = await signInWithPopup(auth, googleProvider);
+      const idToken = await credential.user.getIdToken();
+      await exchangeSession(idToken);
+      await auth.signOut();
+      router.push('/dashboard');
+      router.refresh();
+    } catch (err) {
+      setError(err.message || 'Google sign-in failed.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main>
+      <div className="card">
+        <h1>Sign in</h1>
+        <form onSubmit={handleEmailPassword}>
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+            disabled={loading}
+          />
+
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+            disabled={loading}
+          />
+
+          <button type="submit" disabled={loading}>
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+
+        <button type="button" className="secondary" onClick={handleGoogle} disabled={loading}>
+          {loading ? 'Please wait…' : 'Continue with Google'}
+        </button>
+
+        {error ? <div className="error">{error}</div> : null}
+      </div>
+    </main>
+  );
+}

--- a/web/app/api/auth/session/route.js
+++ b/web/app/api/auth/session/route.js
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { adminAuth } from '@/lib/firebaseAdmin';
+
+const SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const runtime = 'nodejs';
+
+export async function POST(request) {
+  try {
+    const { idToken } = await request.json();
+
+    if (!idToken) {
+      return NextResponse.json({ error: 'Missing idToken' }, { status: 400 });
+    }
+
+    await adminAuth.verifyIdToken(idToken);
+    const sessionCookie = await adminAuth.createSessionCookie(idToken, {
+      expiresIn: SESSION_MAX_AGE_MS
+    });
+
+    const response = NextResponse.json({ status: 'ok' });
+    response.cookies.set({
+      name: '__session',
+      value: sessionCookie,
+      maxAge: SESSION_MAX_AGE_MS / 1000,
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/'
+    });
+
+    return response;
+  } catch (error) {
+    console.error('Failed to create session cookie', error);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+}

--- a/web/app/api/businesses/route.js
+++ b/web/app/api/businesses/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import pool from '@/lib/db';
+import { AuthError, requireAuth } from '@/lib/authServer';
+
+export const runtime = 'nodejs';
+
+export async function GET(request) {
+  try {
+    const session = await requireAuth(request);
+    const [rows] = await pool.query(
+      `SELECT id, name, organization_id AS organizationId
+         FROM businesses
+        WHERE organization_id = ?
+        ORDER BY name ASC`,
+      [session.organizationId]
+    );
+
+    return NextResponse.json({ businesses: rows });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.statusCode });
+    }
+
+    console.error('Failed to load businesses', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/web/app/dashboard/page.js
+++ b/web/app/dashboard/page.js
@@ -1,0 +1,28 @@
+import { redirect } from 'next/navigation';
+import { AuthError, requireAuth } from '@/lib/authServer';
+
+export default async function DashboardPage() {
+  try {
+    const session = await requireAuth();
+
+    return (
+      <div className="dashboard">
+        <h1>Dashboard</h1>
+        <p>Signed in as <strong>{session.email || session.firebaseUid}</strong></p>
+        <p>
+          Organization ID: <strong>{session.organizationId}</strong>
+        </p>
+        <p>
+          Role: <strong>{session.role}</strong>
+        </p>
+        <pre>{JSON.stringify(session, null, 2)}</pre>
+      </div>
+    );
+  } catch (error) {
+    if (error instanceof AuthError && error.statusCode >= 400 && error.statusCode < 500) {
+      redirect('/signin');
+    }
+
+    throw error;
+  }
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,83 @@
+:root {
+  color-scheme: light dark;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #f5f5f5;
+  color: #111827;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.card {
+  background: white;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
+  width: 100%;
+  max-width: 420px;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+input {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #d1d5db;
+  margin-bottom: 1rem;
+}
+
+button {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: none;
+  background: #2563eb;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+button.secondary {
+  background: #4b5563;
+  margin-top: 0.75rem;
+}
+
+.error {
+  margin-top: 1rem;
+  color: #b91c1c;
+}
+
+.dashboard {
+  padding: 3rem;
+}
+
+.dashboard h1 {
+  margin-top: 0;
+}
+
+.dashboard pre {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+}

--- a/web/app/layout.js
+++ b/web/app/layout.js
@@ -1,0 +1,14 @@
+import './globals.css';
+
+export const metadata = {
+  title: 'Livedrives App',
+  description: 'Dashboard for managing businesses and runs'
+};
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/web/app/page.js
+++ b/web/app/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function IndexPage() {
+  redirect('/dashboard');
+}

--- a/web/jsconfig.json
+++ b/web/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"],
+      "@/lib/*": ["lib/*"],
+      "@/app/*": ["app/*"]
+    }
+  }
+}

--- a/web/lib/authServer.js
+++ b/web/lib/authServer.js
@@ -1,0 +1,68 @@
+import { cookies } from 'next/headers';
+import pool from '@/lib/db';
+import { adminAuth } from '@/lib/firebaseAdmin';
+
+const SESSION_COOKIE_NAME = '__session';
+
+export class AuthError extends Error {
+  constructor(statusCode = 401, message = 'Unauthorized') {
+    super(message);
+    this.name = 'AuthError';
+    this.statusCode = statusCode;
+  }
+}
+
+async function getSessionCookie(request) {
+  if (request?.cookies) {
+    const cookie = typeof request.cookies.get === 'function'
+      ? request.cookies.get(SESSION_COOKIE_NAME)
+      : request.cookies[SESSION_COOKIE_NAME];
+
+    return cookie?.value ?? cookie ?? null;
+  }
+
+  return cookies().get(SESSION_COOKIE_NAME)?.value ?? null;
+}
+
+export async function requireAuth(request) {
+  const sessionCookie = await getSessionCookie(request);
+
+  if (!sessionCookie) {
+    throw new AuthError(401, 'Missing session cookie');
+  }
+
+  let decoded;
+  try {
+    decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+  } catch (error) {
+    throw new AuthError(401, 'Invalid session cookie');
+  }
+
+  const [rows] = await pool.query(
+    `SELECT u.id            AS userId,
+            u.firebase_uid  AS firebaseUid,
+            u.email         AS email,
+            u.name          AS name,
+            m.organization_id AS organizationId,
+            m.role          AS role
+       FROM users u
+       JOIN user_org_members m ON m.user_id = u.id
+      WHERE u.firebase_uid = ?
+      ORDER BY m.created_at IS NULL, m.id
+      LIMIT 1`,
+    [decoded.uid]
+  );
+
+  if (!rows.length) {
+    throw new AuthError(403, 'User is not linked to an organization');
+  }
+
+  return {
+    userId: rows[0].userId,
+    firebaseUid: rows[0].firebaseUid,
+    email: rows[0].email,
+    name: rows[0].name,
+    organizationId: rows[0].organizationId,
+    role: rows[0].role
+  };
+}

--- a/web/lib/db.js
+++ b/web/lib/db.js
@@ -1,0 +1,44 @@
+import mysql from 'mysql2/promise';
+import { readFileSync, existsSync } from 'fs';
+
+let pool = globalThis.__livedrivesPool;
+
+if (!pool) {
+  const config = {
+    host: process.env.DB_HOST || 'localhost',
+    port: Number(process.env.DB_PORT || 3306),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    waitForConnections: true,
+    connectionLimit: Number(process.env.DB_POOL_SIZE || 10),
+    queueLimit: 0,
+    timezone: 'Z',
+    dateStrings: false,
+    supportBigNumbers: true,
+    bigNumberStrings: false,
+    decimalNumbers: true,
+    namedPlaceholders: false
+  };
+
+  if (process.env.DB_SOCKET_PATH) {
+    config.socketPath = process.env.DB_SOCKET_PATH;
+    delete config.host;
+    delete config.port;
+  }
+
+  if (process.env.DB_SSL_CA && existsSync(process.env.DB_SSL_CA)) {
+    config.ssl = {
+      ca: readFileSync(process.env.DB_SSL_CA, 'utf8'),
+      rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false'
+    };
+  }
+
+  pool = mysql.createPool(config);
+
+  if (process.env.NODE_ENV !== 'production') {
+    globalThis.__livedrivesPool = pool;
+  }
+}
+
+export default pool;

--- a/web/lib/firebaseAdmin.js
+++ b/web/lib/firebaseAdmin.js
@@ -1,0 +1,24 @@
+import { getApps, initializeApp, cert } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n');
+
+if (!projectId || !clientEmail || !privateKey) {
+  throw new Error('Missing Firebase Admin credentials');
+}
+
+if (!getApps().length) {
+  initializeApp({
+    credential: cert({
+      projectId,
+      clientEmail,
+      privateKey
+    })
+  });
+}
+
+const adminAuth = getAuth();
+
+export { adminAuth };

--- a/web/lib/firebaseClient.js
+++ b/web/lib/firebaseClient.js
@@ -1,0 +1,25 @@
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID
+};
+
+function getFirebaseApp() {
+  if (!getApps().length) {
+    return initializeApp(firebaseConfig);
+  }
+
+  return getApp();
+}
+
+const app = getFirebaseApp();
+const auth = getAuth(app);
+
+auth.useDeviceLanguage();
+
+export { app, auth };

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: false
+  }
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "livedrives-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "firebase": "^10.12.2",
+    "firebase-admin": "^12.6.0",
+    "mysql2": "^3.11.0",
+    "next": "^14.2.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold a new Next.js App Router project under /web with basic layout and styling
- add Firebase client/admin helpers, MySQL pooling, and a reusable requireAuth() verifier
- implement the signin page, session cookie exchange endpoint, businesses API route, and protected dashboard shell

## Testing
- npm install *(fails: registry returned 403 for firebase package in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68df5f7aad148320b1fc5a6647aba665